### PR TITLE
Added license to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "engines": {
     "node": "*"
   },
+  "license": "MIT",
   "keywords": [
     "css", "colors", "names"
   ]


### PR DESCRIPTION
I see that it's listed in the README, but this helps computers know the license too.