### PR TITLE
Remove non-essential files from npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,5 +21,8 @@
   "license": "MIT",
   "keywords": [
     "css", "colors", "names"
+  ],
+  "files": [
+    "css-color-names.json"
   ]
 }


### PR DESCRIPTION
The readme file is included by default.